### PR TITLE
fix typos

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -20,8 +20,10 @@ Certify is here to make this possible.
 What is it?
 -----------
 
-This **MPL Licensed** CA Bundle is extracted from the Mozilla Included CA
-Certs.
+This **MPL Licensed** CA Bundle is extracted from the `Mozilla Included CA
+Certificate List`_.
+
+.. _Mozilla Included CA Certificate List: https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/included/
 
 
 Contents:


### PR DESCRIPTION
official mozilla CA cert bundle name pulled from [here](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/included/)
