### PR TITLE
Fix link to Mozilla Included CA Certificate List

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -25,7 +25,7 @@ What is it?
 This **MPL Licensed** CA Bundle is extracted from the `Mozilla Included CA
 Certificate List`_.
 
-.. _Mozilla Included CA Certificate List: https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/included/
+.. _Mozilla Included CA Certificate List: https://wiki.mozilla.org/CA/Included_Certificates
 
 
 How do I use it?


### PR DESCRIPTION
Original link now redirects to the Mozilla wiki.